### PR TITLE
Link porttime as well as portmidi library.

### DIFF
--- a/portmidi.go
+++ b/portmidi.go
@@ -15,7 +15,7 @@
 // Package portmidi provides PortMidi bindings.
 package portmidi
 
-// #cgo LDFLAGS: -lportmidi
+// #cgo LDFLAGS: -lportmidi -lporttime
 // #include <stdlib.h>
 // #include <portmidi.h>
 // #include <porttime.h>


### PR DESCRIPTION
I didn't test with the version of libportmidi you mention in the readme, but with v 200 I had to link libporttime in addition to libportmidi otherwise I got a linker error. Does v 217 merge the libs into one or something?
