### PR TITLE
Send sysex

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -123,7 +123,10 @@ func (s *Stream) WriteShort(status int64, data1 int64, data2 int64) error {
 
 // Writes a system exclusive MIDI message to the output stream.
 func (s *Stream) WriteSysEx(when Timestamp, msg string) error {
-	return convertToError(C.Pm_WriteSysEx(unsafe.Pointer(s.pmStream), C.PmTimestamp(when), nil))
+	msgCstr := C.CString(msg)
+	defer C.free(unsafe.Pointer(msgCstr))
+	msgUcstr := (*C.uchar)(unsafe.Pointer(msgCstr))
+	return convertToError(C.Pm_WriteSysEx(unsafe.Pointer(s.pmStream), C.PmTimestamp(when), msgUcstr))
 }
 
 // Filters incoming stream based on channel.


### PR DESCRIPTION
Looks like `WriteSysEx` was stubbed out. This patch works for me, although I can't get gdb or valgrind to work with go programs, so I'm not sure it's freeing memory correctly.

Here's a test program:
https://gist.github.com/adsr/ecab341fef25f0fcf906

Run `amidi -p virtual -d`, and then `go run test.go 'Virtual RawMIDI'`. You should then see output from amidi. 
