### PR TITLE
add -lporttime to LDFLAGS

### DIFF
--- a/portmidi.go
+++ b/portmidi.go
@@ -15,7 +15,7 @@
 // Package portmidi provides PortMidi bindings.
 package portmidi
 
-// #cgo LDFLAGS: -lportmidi
+// #cgo LDFLAGS: -lportmidi -lporttime
 // #include <stdlib.h>
 // #include <portmidi.h>
 // #include <porttime.h>


### PR DESCRIPTION
This makes it build correctly under Linux.