### PR TITLE
fix the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ portmidi.Initialize()
 ~~~ go
 portmidi.CountDevices() // returns the number of MIDI devices
 portmidi.GetDeviceInfo(deviceId) // returns info about a MIDI device
-portmidi.GetDefaultInputDeviceId() // returns the ID of the system default input
-portmidi.GetDefaultOutputDeviceId() // returns the ID of the system default output
+portmidi.GetDefaultInputDeviceID() // returns the ID of the system default input
+portmidi.GetDefaultOutputDeviceID() // returns the ID of the system default output
 ~~~
 
 ### Write to a MIDI Device

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ portmidi.Initialize()
 
 ~~~ go
 portmidi.CountDevices() // returns the number of MIDI devices
-portmidi.GetDeviceInfo(deviceId) // returns info about a MIDI device
-portmidi.GetDefaultInputDeviceID() // returns the ID of the system default input
-portmidi.GetDefaultOutputDeviceID() // returns the ID of the system default output
+portmidi.DeviceInfo(deviceId) // returns info about a MIDI device
+portmidi.DefaultInputDeviceID() // returns the ID of the system default input
+portmidi.DefaultOutputDeviceID() // returns the ID of the system default output
 ~~~
 
 ### Write to a MIDI Device

--- a/example_test.go
+++ b/example_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ExampleWriteSysEx() {
-	out, err := portmidi.NewOutputStream(portmidi.GetDefaultOutputDeviceID(), 1024, 0)
+	out, err := portmidi.NewOutputStream(portmidi.DefaultOutputDeviceID(), 1024, 0)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -19,7 +19,7 @@ func ExampleWriteSysEx() {
 }
 
 func ExampleWriteSysExBytes() {
-	out, err := portmidi.NewOutputStream(portmidi.GetDefaultOutputDeviceID(), 1024, 0)
+	out, err := portmidi.NewOutputStream(portmidi.DefaultOutputDeviceID(), 1024, 0)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -30,7 +30,7 @@ func ExampleWriteSysExBytes() {
 }
 
 func ExampleReadSysExBytes() {
-	in, err := portmidi.NewInputStream(portmidi.GetDefaultInputDeviceID(), 1024)
+	in, err := portmidi.NewInputStream(portmidi.DefaultInputDeviceID(), 1024)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ExampleWriteSysEx() {
-	out, err := portmidi.NewOutputStream(portmidi.GetDefaultOutputDeviceId(), 1024, 0)
+	out, err := portmidi.NewOutputStream(portmidi.GetDefaultOutputDeviceID(), 1024, 0)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -19,7 +19,7 @@ func ExampleWriteSysEx() {
 }
 
 func ExampleWriteSysExBytes() {
-	out, err := portmidi.NewOutputStream(portmidi.GetDefaultOutputDeviceId(), 1024, 0)
+	out, err := portmidi.NewOutputStream(portmidi.GetDefaultOutputDeviceID(), 1024, 0)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -30,7 +30,7 @@ func ExampleWriteSysExBytes() {
 }
 
 func ExampleReadSysExBytes() {
-	in, err := portmidi.NewInputStream(portmidi.GetDefaultInputDeviceId(), 1024)
+	in, err := portmidi.NewInputStream(portmidi.GetDefaultInputDeviceID(), 1024)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/portmidi.go
+++ b/portmidi.go
@@ -55,13 +55,13 @@ func Terminate() error {
 }
 
 // Returns the default input device's ID.
-func GetDefaultInputDeviceId() DeviceId {
-	return DeviceId(C.Pm_GetDefaultInputDeviceID())
+func GetDefaultInputDeviceID() DeviceID {
+	return DeviceID(C.Pm_GetDefaultInputDeviceID())
 }
 
 // Returns the default output device's ID.
-func GetDefaultOutputDeviceId() DeviceId {
-	return DeviceId(C.Pm_GetDefaultOutputDeviceID())
+func GetDefaultOutputDeviceID() DeviceID {
+	return DeviceID(C.Pm_GetDefaultOutputDeviceID())
 }
 
 // Returns the number of MIDI devices.
@@ -70,7 +70,7 @@ func CountDevices() int {
 }
 
 // Returns the device info for the device indentified with deviceId.
-func GetDeviceInfo(deviceId DeviceId) *DeviceInfo {
+func GetDeviceInfo(deviceId DeviceID) *DeviceInfo {
 	info := C.Pm_GetDeviceInfo(C.PmDeviceID(deviceId))
 	return &DeviceInfo{
 		Interface:         C.GoString(info.interf),

--- a/portmidi.go
+++ b/portmidi.go
@@ -54,23 +54,23 @@ func Terminate() error {
 	return convertToError(C.Pm_Terminate())
 }
 
-// Returns the default input device's ID.
-func GetDefaultInputDeviceID() DeviceID {
+// DefaultInputDeviceID returns the default input device's ID.
+func DefaultInputDeviceID() DeviceID {
 	return DeviceID(C.Pm_GetDefaultInputDeviceID())
 }
 
-// Returns the default output device's ID.
-func GetDefaultOutputDeviceID() DeviceID {
+// DefaultOutputDeviceID returns the default output device's ID.
+func DefaultOutputDeviceID() DeviceID {
 	return DeviceID(C.Pm_GetDefaultOutputDeviceID())
 }
 
-// Returns the number of MIDI devices.
+// CountDevices returns the number of MIDI devices.
 func CountDevices() int {
 	return int(C.Pm_CountDevices())
 }
 
-// Returns the device info for the device indentified with deviceId.
-func GetDeviceInfo(deviceId DeviceID) *DeviceInfo {
+// Info returns the device info for the device indentified with deviceId.
+func Info(deviceId DeviceID) *DeviceInfo {
 	info := C.Pm_GetDeviceInfo(C.PmDeviceID(deviceId))
 	return &DeviceInfo{
 		Interface:         C.GoString(info.interf),

--- a/stream.go
+++ b/stream.go
@@ -54,12 +54,12 @@ type Event struct {
 
 // Stream represents a portmidi stream.
 type Stream struct {
-	deviceId DeviceId
+	deviceId DeviceID
 	pmStream *C.PmStream
 }
 
 // Initializes a new input stream.
-func NewInputStream(deviceId DeviceId, bufferSize int64) (stream *Stream, err error) {
+func NewInputStream(deviceId DeviceID, bufferSize int64) (stream *Stream, err error) {
 	var str *C.PmStream
 	errCode := C.Pm_OpenInput(
 		(*unsafe.Pointer)(unsafe.Pointer(&str)),
@@ -74,7 +74,7 @@ func NewInputStream(deviceId DeviceId, bufferSize int64) (stream *Stream, err er
 }
 
 // Initializes a new output stream.
-func NewOutputStream(deviceId DeviceId, bufferSize int64, latency int64) (stream *Stream, err error) {
+func NewOutputStream(deviceId DeviceID, bufferSize int64, latency int64) (stream *Stream, err error) {
 	var str *C.PmStream
 	errCode := C.Pm_OpenOutput(
 		(*unsafe.Pointer)(unsafe.Pointer(&str)),

--- a/stream.go
+++ b/stream.go
@@ -67,7 +67,7 @@ func NewInputStream(deviceId DeviceID, bufferSize int64) (stream *Stream, err er
 	if errCode != 0 {
 		return nil, convertToError(errCode)
 	}
-	if info := GetDeviceInfo(deviceId); !info.IsInputAvailable {
+	if info := Info(deviceId); !info.IsInputAvailable {
 		return nil, ErrInputUnavailable
 	}
 	return &Stream{deviceId: deviceId, pmStream: str}, nil
@@ -82,7 +82,7 @@ func NewOutputStream(deviceId DeviceID, bufferSize int64, latency int64) (stream
 	if errCode != 0 {
 		return nil, convertToError(errCode)
 	}
-	if info := GetDeviceInfo(deviceId); !info.IsOutputAvailable {
+	if info := Info(deviceId); !info.IsOutputAvailable {
 		return nil, ErrOutputUnavailable
 	}
 	return &Stream{deviceId: deviceId, pmStream: str}, nil


### PR DESCRIPTION
[This PR](https://github.com/rakyll/portmidi/commit/825ee38909a5df2a856a701212ae5360515ff087) broke the build by renaming a type without refactoring its usage. My PR is just a refactoring so the code base does use the new type name and compiles.

P.s: we might want to set travis on this repo so we can more easily catch these issues.