### PR TITLE
Add -lporttime to LDFLAGS for Linux compiles.

### DIFF
--- a/portmidi.go
+++ b/portmidi.go
@@ -17,6 +17,7 @@ package portmidi
 
 // #cgo CFLAGS:  -I/usr/local/include
 // #cgo LDFLAGS: -lportmidi -L/usr/local/lib
+// #cgo linux LDFLAGS: -lporttime
 //
 // #include <stdlib.h>
 // #include <portmidi.h>


### PR DESCRIPTION
This was required for me to install the package on Ubuntu 16.0.1