### PR TITLE
Remove package doc from stream.go

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package portmidi provides portmidi bindings.
 package portmidi
 
 // #cgo LDFLAGS: -lportmidi


### PR DESCRIPTION
If it's specified repeatedly, it'll appear repeatedly in e.g. godoc.org/github.com/rakyll/portmidi.

Remove the copy in stream.go to let portmidi.go be canonical.