### PR TITLE
rm ld -lporttime

### DIFF
--- a/portmidi.go
+++ b/portmidi.go
@@ -17,7 +17,6 @@ package portmidi
 
 // #cgo CFLAGS:  -I/usr/local/include
 // #cgo LDFLAGS: -lportmidi -L/usr/local/lib
-// #cgo linux LDFLAGS: -lporttime
 //
 // #include <stdlib.h>
 // #include <portmidi.h>


### PR DESCRIPTION
Cannot compile on Gentoo Linux, linker whines that it can't find libporttime. Removing linker flag allows successful compile, and testing with real hardware shows no issues. This is with `portmidi-src-217.zip`, not sure if another distro inappropriately breaks out a separate library .so?